### PR TITLE
fix: attributes of `<i18n>` tag not highlighted

### DIFF
--- a/syntaxes/Whisthub Component.sublime-syntax
+++ b/syntaxes/Whisthub Component.sublime-syntax
@@ -30,7 +30,7 @@ contexts:
       captures:
         1: punctuation.definition.tag.begin.html
         2: entity.name.tag.style.html
-      push: i18n-css
+      push: i18n-tsv
     - match: (</)((?i:i18n){{tag_name_break}})
       captures:
         1: punctuation.definition.tag.begin.html
@@ -42,18 +42,19 @@ contexts:
     - include: tag-end
 
   i18n-common:
-    - meta_prepend: true
+    - include: tag-attributes
+    - include: tag-end-self-closing
     - include: i18n-lang-attribute
 
-  i18n-css:
+  i18n-tsv:
     # for compatibility with ST builds before 4114
     - meta_scope: meta.tag.style.begin.html
     - match: '>'
       scope: punctuation.definition.tag.end.html
-      set: i18n-css-content
+      set: i18n-tsv-content
     - include: i18n-common
 
-  i18n-css-content:
+  i18n-tsv-content:
     # for compatibility with ST builds before 4114
     - meta_include_prototype: false
     - match: '{{i18n_content_begin}}'
@@ -80,7 +81,7 @@ contexts:
       scope: punctuation.separator.key-value.html
       set: i18n-lang-attribute-value
     - match: (?=\S)
-      set: i18n-css
+      set: i18n-tsv
 
   i18n-lang-attribute-value:
     - meta_include_prototype: false
@@ -153,6 +154,6 @@ contexts:
         - tag-generic-attribute-value
     - match: (?=\S)
       set:
-        - i18n-css
+        - i18n-tsv
         - tag-generic-attribute-meta
         - tag-generic-attribute-value

--- a/syntaxes/Whisthub Component.sublime-syntax
+++ b/syntaxes/Whisthub Component.sublime-syntax
@@ -42,9 +42,9 @@ contexts:
     - include: tag-end
 
   i18n-common:
+    - include: i18n-lang-attribute
     - include: tag-attributes
     - include: tag-end-self-closing
-    - include: i18n-lang-attribute
 
   i18n-tsv:
     # for compatibility with ST builds before 4114

--- a/syntaxes/Whisthub Component.sublime-syntax
+++ b/syntaxes/Whisthub Component.sublime-syntax
@@ -61,13 +61,13 @@ contexts:
       captures:
         1: comment.block.html punctuation.definition.comment.begin.html
       pop: 1  # make sure to match only once
-      embed: scope:source.css
-      embed_scope: source.css.embedded.html
+      embed: scope:source.json
+      embed_scope: source.json.embedded.html
       escape: '{{i18n_content_end}}'
       escape_captures:
-        1: source.css.embedded.html
+        1: source.json.embedded.html
         2: comment.block.html punctuation.definition.comment.end.html
-        3: source.css.embedded.html
+        3: source.json.embedded.html
         4: comment.block.html punctuation.definition.comment.end.html
 
   i18n-lang-attribute:

--- a/syntaxes/Whisthub Component.sublime-syntax
+++ b/syntaxes/Whisthub Component.sublime-syntax
@@ -110,7 +110,7 @@ contexts:
             - include: i18n-common
         - tag-generic-attribute-meta
         - tag-generic-attribute-value
-    - match: (?i)(?=yaml{{unquoted_attribute_break}}|\'yaml\'|"yaml")
+    - match: (?i)(?=ya?ml{{unquoted_attribute_break}}|\'ya?ml\'|"ya?ml")
       set:
         -   - meta_scope: meta.tag.style.begin.html
             - match: '>'


### PR DESCRIPTION
Even though the `lang` attribute got highlighted, we broke the highlighting of the *other* attributes. That's because a `<style>` tag is actually different than another tag in html. Fixed now.